### PR TITLE
Fallback to othing if O_CLOEXEC does not exist. (Debian 6)

### DIFF
--- a/examples/test.c
+++ b/examples/test.c
@@ -63,7 +63,7 @@ static void periodic_task(uev_t UNUSED(*w), void UNUSED(*arg), int UNUSED(events
 
 static void signal_cb(uev_t *w, void *UNUSED(arg), int UNUSED(events))
 {
-	fprintf(stderr, w->signo == SIGINT ? "^Cv" : "^\v");
+	fprintf(stderr, ((uev_private_t*)w)->signo == SIGINT ? "^Cv" : "^\v");
 }
 
 static void pipe_read_cb(uev_t UNUSED(*w), void UNUSED(*arg), int UNUSED(events))

--- a/io.c
+++ b/io.c
@@ -46,10 +46,10 @@ int uev_io_init(uev_ctx_t *ctx, uev_t *w, uev_cb_t *cb, void *arg, int fd, int e
 		return -1;
 	}
 
-	if (uev_watcher_init(ctx, w, UEV_IO_TYPE, cb, arg, fd, events))
+	if (uev_watcher_init(ctx, (uev_private_t*)w, UEV_IO_TYPE, cb, arg, fd, events))
 		return -1;
 
-	return uev_watcher_start(w);
+	return uev_watcher_start((uev_private_t*)w);
 }
 
 /**
@@ -62,10 +62,11 @@ int uev_io_init(uev_ctx_t *ctx, uev_t *w, uev_cb_t *cb, void *arg, int fd, int e
  */
 int uev_io_set(uev_t *w, int fd, int events)
 {
+        uev_private_t *_w = (uev_private_t*)w;
 	/* Ignore any errors, only to clean up anything lingering ... */
 	uev_io_stop(w);
 
-	return uev_io_init(w->ctx, w, (uev_cb_t *)w->cb, w->arg, fd, events);
+	return uev_io_init(w->ctx, w, (uev_cb_t *)_w->cb, _w->arg, fd, events);
 }
 
 /**
@@ -76,7 +77,7 @@ int uev_io_set(uev_t *w, int fd, int events)
  */
 int uev_io_start(uev_t *w)
 {
-	return uev_io_set(w, w->fd, w->events);
+	return uev_io_set(w, w->fd, ((uev_private_t*)w)->events);
 }
 
 /**
@@ -87,7 +88,7 @@ int uev_io_start(uev_t *w)
  */
 int uev_io_stop(uev_t *w)
 {
-	return uev_watcher_stop(w);
+	return uev_watcher_stop((uev_private_t*)w);
 }
 
 /**

--- a/private.h
+++ b/private.h
@@ -45,39 +45,19 @@ typedef struct {
 	int             running;
 	int             fd;     /* For epoll() */
 	uint32_t        errors;
-	LIST_HEAD(,uev) watchers;
+	LIST_HEAD(,uev_private) watchers;
 } uev_ctx_t;
 
 /* Forward declare due to dependencys, don't try this at home kids. */
 struct uev;
-
-/* This is used to hide all private data members in uev_t */
-#define uev_private_t                                           \
-	LIST_ENTRY(uev) link;   /* For queue.h linked list */   \
-								\
-	int             active;                                 \
-	int             events;                                 \
-								\
-	/* Watcher callback with optional argument */           \
-	void          (*cb)(struct uev *, void *, int);         \
-	void           *arg;                                    \
-								\
-	/* Timer watchers, time in milliseconds */		\
-	int             timeout;                                \
-	int             period;                                 \
-								\
-	/* Signal watchers */                                   \
-	int             signo;                                  \
-								\
-	/* Watcher type */					\
-	uev_type_t
+struct uev_private;
 
 /* Internal API for dealing with generic watchers */
-int uev_watcher_init (uev_ctx_t *ctx, struct uev *w, uev_type_t type,
+int uev_watcher_init (uev_ctx_t *ctx, struct uev_private *w, uev_type_t type,
 		      void (*cb)(struct uev *, void *, int), void *arg,
 		      int fd, int events);
-int uev_watcher_start(struct uev *w);
-int uev_watcher_stop (struct uev *w);
+int uev_watcher_start(struct uev_private *w);
+int uev_watcher_stop (struct uev_private *w);
 
 #endif /* LIBUEV_PRIVATE_H_ */
 

--- a/uev.c
+++ b/uev.c
@@ -25,6 +25,9 @@
 
 #include <errno.h>
 #include <fcntl.h>		/* O_CLOEXEC */
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0             /* Fallback to nothing if O_CLOEXEC does not exist */
+#endif
 #include <string.h>		/* memset() */
 #include <sys/epoll.h>
 #include <sys/signalfd.h>	/* struct signalfd_siginfo */

--- a/uev.c
+++ b/uev.c
@@ -24,10 +24,7 @@
  */
 
 #include <errno.h>
-#include <fcntl.h>		/* O_CLOEXEC */
-#ifndef O_CLOEXEC
-#define O_CLOEXEC 0             /* Fallback to nothing if O_CLOEXEC does not exist */
-#endif
+#include <fcntl.h>		/* EPOLL_CLOEXEC */
 #include <string.h>		/* memset() */
 #include <sys/epoll.h>
 #include <sys/signalfd.h>	/* struct signalfd_siginfo */
@@ -40,7 +37,7 @@
 
 static int _init(uev_ctx_t *ctx, int close_old)
 {
-	int fd = epoll_create1(O_CLOEXEC);
+	int fd = epoll_create1(EPOLL_CLOEXEC);
 
 	if (fd < 0)
 		return -1;
@@ -60,7 +57,7 @@ static int is_valid_fd(int fd)
 }
 
 /* Private to libuEv, do not use directly! */
-int uev_watcher_init(uev_ctx_t *ctx, uev_t *w, uev_type_t type, uev_cb_t *cb, void *arg, int fd, int events)
+int uev_watcher_init(uev_ctx_t *ctx, uev_private_t *w, uev_type_t type, uev_cb_t *cb, void *arg, int fd, int events)
 {
 	if (!ctx || !w) {
 		errno = EINVAL;
@@ -79,7 +76,7 @@ int uev_watcher_init(uev_ctx_t *ctx, uev_t *w, uev_type_t type, uev_cb_t *cb, vo
 }
 
 /* Private to libuEv, do not use directly! */
-int uev_watcher_start(uev_t *w)
+int uev_watcher_start(uev_private_t *w)
 {
 	struct epoll_event ev;
 
@@ -105,7 +102,7 @@ int uev_watcher_start(uev_t *w)
 }
 
 /* Private to libuEv, do not use directly! */
-int uev_watcher_stop(uev_t *w)
+int uev_watcher_stop(uev_private_t *w)
 {
 	if (!w) {
 		errno = EINVAL;
@@ -160,7 +157,7 @@ int uev_exit(uev_ctx_t *ctx)
 	}
 
 	while (!LIST_EMPTY(&ctx->watchers)) {
-		uev_t *w = LIST_FIRST(&ctx->watchers);
+		uev_private_t *w = LIST_FIRST(&ctx->watchers);
 
 		/* Remove from internal list */
 		LIST_REMOVE(w, link);
@@ -170,15 +167,15 @@ int uev_exit(uev_ctx_t *ctx)
 
 		switch (w->type) {
 		case UEV_TIMER_TYPE:
-			uev_timer_stop(w);
+			uev_timer_stop((uev_t*)w);
 			break;
 
 		case UEV_SIGNAL_TYPE:
-			uev_signal_stop(w);
+			uev_signal_stop((uev_t*)w);
 			break;
 
 		case UEV_IO_TYPE:
-			uev_io_stop(w);
+			uev_io_stop((uev_t*)w);
 			break;
 		}
 	}
@@ -207,7 +204,7 @@ int uev_exit(uev_ctx_t *ctx)
 int uev_run(uev_ctx_t *ctx, int flags)
 {
 	int result = 0, timeout = -1;
-	uev_t *w;
+	uev_private_t *w;
 
         if (!ctx || ctx->fd < 0) {
 		errno = EINVAL;
@@ -223,7 +220,7 @@ int uev_run(uev_ctx_t *ctx, int flags)
 	/* Start all dormant timers */
 	LIST_FOREACH(w, &ctx->watchers, link) {
 		if (UEV_TIMER_TYPE == w->type)
-			uev_timer_set(w, w->timeout, w->period);
+			uev_timer_set((uev_t*)w, w->timeout, w->period);
 	}
 
 	while (ctx->running) {
@@ -243,13 +240,13 @@ int uev_run(uev_ctx_t *ctx, int flags)
 		}
 
 		for (i = 0; ctx->running && i < nfds; i++) {
-			w = (uev_t *)events[i].data.ptr;
+			w = (uev_private_t *)events[i].data.ptr;
 
 			if (events[i].events & (EPOLLHUP | EPOLLERR)) {
 				ctx->errors++;
 
 				if (ctx->errors >= 42) {
-					uev_t *tmp, *retry = w;;
+					uev_private_t *tmp, *retry = w;
 
 					/* If not valid anymore, try to remove, ignore any errors. */
 					if (!is_valid_fd(w->fd))
@@ -300,11 +297,11 @@ int uev_run(uev_ctx_t *ctx, int flags)
 			}
 
 			if (w->cb)
-				w->cb(w, w->arg, events[i].events & UEV_EVENT_MASK);
+				w->cb((uev_t*)w, w->arg, events[i].events & UEV_EVENT_MASK);
 
 			if (UEV_TIMER_TYPE == w->type) {
 				if (!w->timeout)
-					uev_timer_stop(w);
+					uev_timer_stop((uev_t*)w);
 			}
 		}
 

--- a/uev.h
+++ b/uev.h
@@ -41,11 +41,36 @@
 #define UEV_NONBLOCK    2
 
 /* Event watcher */
-typedef struct uev {
+
+
+typedef struct uev_private {
 	int             fd;
 	uev_ctx_t      *ctx;
 
-	uev_private_t   type;
+/* This is used to hide all private data members in uev_t */
+        LIST_ENTRY(uev_private) link;   /* For queue.h linked list */
+
+        int             active;
+        int             events;
+
+        /* Watcher callback with optional argument */
+        void          (*cb)(struct uev *, void *, int);
+        void           *arg;
+
+        /* Timer watchers, time in milliseconds */     
+        int             timeout;
+        int             period;
+
+        /* Signal watchers */
+        int             signo;
+
+        uev_type_t      type;
+} uev_private_t;
+
+typedef struct uev {
+        int             fd;
+        uev_ctx_t      *ctx;
+        char            filler[sizeof (uev_private_t) - sizeof (int) - sizeof (uev_ctx_t*)];
 } uev_t;
 
 /* Generic callback for watchers */


### PR DESCRIPTION
I guess older kernels don't have this? Anyway, I had to do something for it to compile on Debian 6, kernel: 

Linux version 2.6.32-5-xen-amd64 (Debian 2.6.32-48squeeze10) (holger@debian.org) (gcc version 4.3.5 (Debian 4.3.5-4) ) #1 SMP Sun Dec 21 18:33:39 UTC 2014