### PR TITLE
O_CLOEXEC does not exist in Debian 6, and apparently EPOLL_CLOEXEC is…

### DIFF
--- a/uev.c
+++ b/uev.c
@@ -37,7 +37,7 @@
 
 static int _init(uev_ctx_t *ctx, int close_old)
 {
-	int fd = epoll_create1(O_CLOEXEC);
+	int fd = epoll_create1(EPOLL_CLOEXEC);
 
 	if (fd < 0)
 		return -1;


### PR DESCRIPTION
… the correct to use anyway.