### PR TITLE
Add support for EPOLLPRI events for i/o watchers

### DIFF
--- a/io.c
+++ b/io.c
@@ -34,7 +34,7 @@
  * @param cb      I/O callback
  * @param arg     Optional callback argument
  * @param fd      File descriptor to watch, or -1 to register an empty watcher
- * @param events  Requested events to watch for, a mask of %UEV_READ and %UEV_WRITE
+ * @param events  Requested events to watch for, a mask of %UEV_READ, %UEV_WRITE and %UEV_PRI
  *
  * @return POSIX OK(0) or non-zero with @param errno set on error.
  */

--- a/private.h
+++ b/private.h
@@ -37,7 +37,7 @@ typedef enum {
 } uev_type_t;
 
 /* Event mask, used internally only. */
-#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE)
+#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE | UEV_PRI)
 
 /* Main libuEv context type */
 typedef struct {

--- a/uev.h
+++ b/uev.h
@@ -34,6 +34,7 @@
 #define UEV_NONE        0
 #define UEV_READ        EPOLLIN
 #define UEV_WRITE       EPOLLOUT
+#define UEV_PRI         EPOLLPRI
 
 /* Run flags */
 #define UEV_ONCE        1


### PR DESCRIPTION
I was trying out your libuev library (an excellent library) for an embedded Linux project, where the program needs to respond to changes in hardware GPIOs (e.g. users pushing buttons and switches).
Unlike regular file descriptors, GPIOs report changes via EPOLLPRI events, not EPOLLIN.
Details: https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
Out of the box, libuev did not support this, but it was very simple to add.

With my changes, it's possible to create a GPIO watcher like this:
```c++
uev_io_init(&ctx, &gpioWatcher, gpioCallback, &app, buttonGpioFd, UEV_PRI);
```

I am submitting my changes to you for review, and hopefully inclusion in the main libuev. Thanks for creating the libuev library, I am really enjoying working with it.
Best wishes!