### PR TITLE
Add edgetrigger and oneshot event types

### DIFF
--- a/io.c
+++ b/io.c
@@ -61,10 +61,9 @@ int uev_io_init(uev_ctx_t *ctx, uev_t *w, uev_cb_t *cb, void *arg, int fd, int e
 int uev_io_set(uev_t *w, int fd, int events)
 {
 
-  if( events & UEV_ONESHOT 
-      && 1 == w->active ) {
-    return uev_watcher_rearm(w);
-  }
+	if( (events & UEV_ONESHOT) && w->active ) {
+  	return uev_watcher_rearm(w);
+	}
 
 	/* Ignore any errors, only to clean up anything lingering ... */
 	uev_io_stop(w);

--- a/io.c
+++ b/io.c
@@ -62,7 +62,7 @@ int uev_io_set(uev_t *w, int fd, int events)
 {
 
 	if ((events & UEV_ONESHOT) && w->active) {
-    return uev_watcher_rearm(w);
+		return uev_watcher_rearm(w);
 	}
 
 	/* Ignore any errors, only to clean up anything lingering ... */

--- a/io.c
+++ b/io.c
@@ -61,8 +61,8 @@ int uev_io_init(uev_ctx_t *ctx, uev_t *w, uev_cb_t *cb, void *arg, int fd, int e
 int uev_io_set(uev_t *w, int fd, int events)
 {
 
-	if( (events & UEV_ONESHOT) && w->active ) {
-  	return uev_watcher_rearm(w);
+	if ((events & UEV_ONESHOT) && w->active) {
+    return uev_watcher_rearm(w);
 	}
 
 	/* Ignore any errors, only to clean up anything lingering ... */

--- a/io.c
+++ b/io.c
@@ -60,6 +60,12 @@ int uev_io_init(uev_ctx_t *ctx, uev_t *w, uev_cb_t *cb, void *arg, int fd, int e
  */
 int uev_io_set(uev_t *w, int fd, int events)
 {
+
+  if( events & UEV_ONESHOT 
+      && 1 == w->active ) {
+    return uev_watcher_rearm(w);
+  }
+
 	/* Ignore any errors, only to clean up anything lingering ... */
 	uev_io_stop(w);
 

--- a/private.h
+++ b/private.h
@@ -38,7 +38,7 @@ typedef enum {
 } uev_type_t;
 
 /* Event mask, used internally only. */
-#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE | UEV_PRI | UEV_HUP | UEV_RDHUP | UEV_ET | UEV_ONESHOT)
+#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE | UEV_PRI | UEV_HUP | UEV_RDHUP | UEV_EDGE | UEV_ONESHOT)
 
 /* Main libuEv context type */
 typedef struct {

--- a/private.h
+++ b/private.h
@@ -38,7 +38,7 @@ typedef enum {
 } uev_type_t;
 
 /* Event mask, used internally only. */
-#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE | UEV_PRI | UEV_HUP)
+#define UEV_EVENT_MASK  (UEV_READ | UEV_WRITE | UEV_PRI | UEV_HUP | UEV_RDHUP | UEV_ET | UEV_ONESHOT)
 
 /* Main libuEv context type */
 typedef struct {
@@ -87,6 +87,7 @@ int uev_watcher_init  (uev_ctx_t *ctx, struct uev *w, uev_type_t type,
 int uev_watcher_start (struct uev *w);
 int uev_watcher_stop  (struct uev *w);
 int uev_watcher_active(struct uev *w);
+int uev_watcher_rearm (struct uev *w);
 
 #endif /* LIBUEV_PRIVATE_H_ */
 

--- a/uev.c
+++ b/uev.c
@@ -133,6 +133,24 @@ int uev_watcher_active(uev_t *w)
 	return w->active;
 }
 
+/* Private to libuEv, do not use directly! */
+int uev_watcher_rearm(uev_t *w)
+{
+	struct epoll_event ev;
+
+	if (!w || w->fd < 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	ev.events   = w->events | EPOLLRDHUP;
+	ev.data.ptr = w;
+	if (epoll_ctl(w->ctx->fd, EPOLL_CTL_MOD, w->fd, &ev) < 0)
+		return -1;
+
+	return 0;
+}
+
 /**
  * Create an event loop context
  * @param ctx  Pointer to an uev_ctx_t context to be initialized

--- a/uev.h
+++ b/uev.h
@@ -36,6 +36,9 @@
 #define UEV_WRITE       EPOLLOUT
 #define UEV_PRI         EPOLLPRI
 #define UEV_HUP         EPOLLHUP
+#define UEV_RDHUP       EPOLLRDHUP
+#define UEV_ET          EPOLLET
+#define UEV_ONESHOT     EPOLLONESHOT
 
 /* Run flags */
 #define UEV_ONCE        1

--- a/uev.h
+++ b/uev.h
@@ -37,7 +37,7 @@
 #define UEV_PRI         EPOLLPRI
 #define UEV_HUP         EPOLLHUP
 #define UEV_RDHUP       EPOLLRDHUP
-#define UEV_ET          EPOLLET
+#define UEV_EDGE        EPOLLET
 #define UEV_ONESHOT     EPOLLONESHOT
 
 /* Run flags */


### PR DESCRIPTION
I'm using oneshot event type after handling the event you must rearm the event. 
First i used the unmodified version of uev_io_set() to rearm. But i noticed uev_exit() was blocking almost forever, because the UEV lib internal list was huge.  So i modified the function so it basically does "epoll_ctl(..., EPOLL_CTL_MOD, ...)" if the IO event is active and oneshot.