### PR TITLE
Fix to build cleanly on Fedora build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the library works.
 ```sh
 ./configure
 make -j5
-make test
+make check
 sudo make install-strip
 sudo ldconfig
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AM_INIT_AUTOMAKE([1.11 foreign dist-xz])
 AM_SILENT_RULES([yes])
 
 AC_CONFIG_SRCDIR(src/uev.c)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_FILES([Makefile src/libuev.pc src/Makefile examples/Makefile tests/Makefile])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,5 @@ TESTS          += event
 
 check_PROGRAMS  = $(TESTS)
 
-# Ignore warnings about unused result, in e.g. write()
-CFLAGS          = -W -Wall -Wextra -Wno-unused-result -Wno-unused-parameter
 CPPFLAGS        = -D_GNU_SOURCE
 LDADD           = -L../src ../src/libuev.la


### PR DESCRIPTION
libuev has been recently [added to Fedora][rpm]. There were two items that require upstream attention:

1. Usage of obsolete autotools macros (#22)
2. Hard-coded CFLAGS in tests (#23)

Both problems are fixed here. While the motivation for doing these changes comes from Fedora, both are sensible things to do in general. 

Also a small README fix.

[rpm]: https://src.fedoraproject.org/rpms/libuev